### PR TITLE
feat: foundational race configuration and segment-aware simulation (#49, #52, #53, #55, #56, #57)

### DIFF
--- a/DEVELOPER_NOTE.md
+++ b/DEVELOPER_NOTE.md
@@ -1,0 +1,48 @@
+# Developer Note: Climb-Aware Pacing Infrastructure
+
+## Architectural Choices & Model Foundation (#49)
+
+To support JSON serialization correctly across varying segment definitions, the segment entities have been designed with simple, primitive properties equipped with public getters and setters. This object-oriented design directly fulfills the requirement specified in issue #49, establishing a serialization-ready model foundation without requiring complex custom JSON converters that may hinder future development.
+
+## Unifying Mixed Segment Types (#55)
+
+The `ISegment` interface was introduced to unify different types of race sections. By standardizing on `TimeSpan Duration { get; }`, the application can predictably query the expected time block of any sequence regardless of its topological or physiological demands. This enables the simulation pipeline to aggregate various route layouts—accommodating the "mixed segment types" outlined in issue #55—while adhering to the Open-Closed Principle. New segment models, such as sprint sections, can be introduced in the future by simply implementing `ISegment`.
+
+## Internal Normalization (#52)
+
+Currently, the simulated paceline expects discrete time intervals to compose rotations properly and allocate exertion periods constraint bounds. `FlatSegment` dynamically resolves target speeds and distances into uniform `TimeSpan` outputs, embedding a guard clause to safely handle zero or negative velocity inputs. Conversely, `ClimbSegment` wraps fixed-time objectives directly from literal seconds. By encapsulating these calculations within the models themselves, the core logic guarantees a normalized interpretation across the `PacelinePlanComposer` before workout projection occurs (#52).
+
+## Next Steps
+
+Integration with parsers should evaluate introducing a strategy pattern or generic converter logic to dynamically yield `ISegment` derivatives. Furthermore, `PacelinePlanComposer` logic will need to be refactored to gracefully segment internal rotations using iterative blocks bound to the cumulative sum of normalized segment durations.
+
+## Race CLI Integration (#57)
+
+The CLI has been updated to accept a targeted race plan via the `--race <file>` flag. Providing this flag overrides any simple `--rotations` configuration globally, effectively unifying segment management and file parsing.
+
+### Race File JSON Sample
+
+```json
+{
+  "name": "WTRL TTT - Greater London Flat",
+  "route": [
+    {
+      "type": "flat",
+      "distanceKm": 5.5,
+      "avgSpeedKph": 43.0
+    },
+    {
+      "type": "climb",
+      "durationSeconds": 300
+    },
+    {
+      "type": "flat",
+      "distanceKm": 10.0,
+      "avgSpeedKph": 45.0
+    }
+  ]
+}
+```
+
+Internally, the `RaceConfigParser` uses a `JsonConverter<ISegment>` discriminative factory within `System.Text.Json`, isolating the casting logic from standard implementation leaks ensuring compatibility across the simulator modules.
+

--- a/ZwiftTTTSim.CLI/Program.cs
+++ b/ZwiftTTTSim.CLI/Program.cs
@@ -3,6 +3,7 @@ using ZwiftTTTSim.CLI;
 using ZwiftTTTSim.Core.Model;
 using ZwiftTTTSim.Core.Services;
 using ZwiftTTTSim.Core.Exporters;
+using ZwiftTTTSim.Core.Model.Config;
 using System.Reflection;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
@@ -91,6 +92,23 @@ var noLogoOption = new Option<bool>(
     description: "Suppress the display of the program logo (default: false).",
     getDefaultValue: () => false);
 
+var raceFileOption = new Option<FileInfo?>(
+    name: "--race",
+    description: "Path to a JSON file containing the sequence of race segments (overrides --rotations)",
+    parseArgument: result =>
+    {
+        var filePath = result.Tokens.Count > 0 ? result.Tokens[0].Value : null;
+        if (filePath == null) return null;
+
+        var fileInfo = new FileInfo(filePath);
+        if (!fileInfo.Exists)
+        {
+            result.ErrorMessage = $"Race file '{fileInfo.FullName}' not found.";
+            return null;
+        }
+
+        return fileInfo;
+    });
 
 rootCommand.AddValidator(commandResult =>
 {
@@ -133,8 +151,31 @@ rootCommand.AddOption(dryRunOption);
 rootCommand.AddOption(verboseOption);
 rootCommand.AddOption(quietOption);
 rootCommand.AddOption(noLogoOption);
-rootCommand.SetHandler((inputFile, rotations, outputFolder, formats, dryRun, verbose, quiet, noLogo) =>
+rootCommand.AddOption(raceFileOption);
+
+rootCommand.SetHandler((System.CommandLine.Invocation.InvocationContext context) =>
 {
+    var inputFile = context.ParseResult.GetValueForOption(inputFileOption);
+    var rotations = context.ParseResult.GetValueForOption(rotationsOption);
+    var outputFolder = context.ParseResult.GetValueForOption(outputFolderOption);
+    var formats = context.ParseResult.GetValueForOption(formatsOption);
+    var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+    var verbose = context.ParseResult.GetValueForOption(verboseOption);
+    var quiet = context.ParseResult.GetValueForOption(quietOption);
+    var noLogo = context.ParseResult.GetValueForOption(noLogoOption);
+    var raceFile = context.ParseResult.GetValueForOption(raceFileOption);
+
+    // Mutual Exclusivity Check (#56)
+    if (raceFile != null && context.ParseResult.FindResultFor(rotationsOption) != null)
+    {
+        if (!quiet)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("Warning: Both --race and --rotations were provided. The --rotations value will be ignored in favor of the race configuration.");
+            Console.ResetColor();
+            Console.WriteLine();
+        }
+    }
 
     // Print header unless --no-logo is specified
     if (!noLogo)
@@ -148,7 +189,14 @@ rootCommand.SetHandler((inputFile, rotations, outputFolder, formats, dryRun, ver
         Console.WriteLine("======================================");
         Console.WriteLine("CLI Parameters:");
         Console.WriteLine($"    Input File: {inputFile?.FullName}");
-        Console.WriteLine($"    Rotations: {rotations}");
+        if (raceFile != null)
+        {
+            Console.WriteLine($"    Race File: {raceFile.FullName} (overrides rotations)");
+        }
+        else
+        {
+            Console.WriteLine($"    Rotations: {rotations}");
+        }
         Console.WriteLine($"    Output Folder: {outputFolder?.FullName}");
         Console.WriteLine($"    Formats ({formats?.Length ?? 0}): {string.Join(", ", formats ?? Array.Empty<string>())}");
         Console.WriteLine($"    Dry Run: {dryRun}");
@@ -245,12 +293,58 @@ rootCommand.SetHandler((inputFile, rotations, outputFolder, formats, dryRun, ver
     }
 
     // Generate paceline workout plan
-    if (!quiet)
-    {
-        Console.WriteLine("Composing paceline plan...");
-    }
     var pacelinePlanComposer = new PacelinePlanComposer();
-    var plan = pacelinePlanComposer.CreatePlan(powerPlans, rotations);
+    PacelinePlan plan;
+    string? effectiveOutputFolder = outputFolder?.FullName;
+
+    if (raceFile != null)
+    {
+        if (!quiet)
+        {
+            Console.WriteLine("Reading and parsing Race JSON file...");
+        }
+        var raceContent = File.ReadAllText(raceFile.FullName);
+        var raceParser = new RaceConfigParser();
+        try
+        {
+            var raceConfig = raceParser.Parse(raceContent);
+            
+            // Use race name for output folder organization if available
+            if (!string.IsNullOrWhiteSpace(raceConfig.Name))
+            {
+                var sanitizedName = string.Join("_", raceConfig.Name.Split(Path.GetInvalidFileNameChars()));
+                effectiveOutputFolder = Path.Combine(effectiveOutputFolder ?? "workouts", sanitizedName);
+            }
+
+            if (verbose)
+            {
+                Console.WriteLine($"Parsed Race Config: {raceConfig.Name} with {raceConfig.Route.Count} segments.");
+            }
+            if (!quiet)
+            {
+                Console.WriteLine("Composing paceline plan using race segments...");
+            }
+            plan = pacelinePlanComposer.CreatePlan(powerPlans, raceConfig.Route);
+        }
+        catch (Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine("Error: Failed to process race configuration:");
+            Console.Error.WriteLine(ex.Message);
+            Console.ResetColor();
+            Environment.Exit(1);
+            return;
+        }
+    }
+    else
+    {
+        if (!quiet)
+        {
+            Console.WriteLine("Composing paceline plan using fixed rotations...");
+        }
+        plan = pacelinePlanComposer.CreatePlan(powerPlans, rotations);
+    }
+
     if (verbose)
     {
         Console.WriteLine("Generated Paceline Plan with {0} pulls:", plan.Pulls.Count);
@@ -317,11 +411,11 @@ rootCommand.SetHandler((inputFile, rotations, outputFolder, formats, dryRun, ver
                         Console.WriteLine("Exporting ZWO files...");
                     }
                     var zwoExporter = new ZwoExporter();
-                    zwoExporter.ExportToFiles(workouts, outputFolder?.FullName);
+                    zwoExporter.ExportToFiles(workouts, effectiveOutputFolder);
                     if (!quiet)
                     {
                         Console.ForegroundColor = ConsoleColor.Green;
-                        Console.WriteLine($"✅ ZWO workouts exported to '{outputFolder?.FullName}' directory");
+                        Console.WriteLine($"✅ ZWO workouts exported to '{effectiveOutputFolder}' directory");
                         Console.ResetColor();
                     }
                     if (verbose)
@@ -340,11 +434,11 @@ rootCommand.SetHandler((inputFile, rotations, outputFolder, formats, dryRun, ver
                         Console.WriteLine("Exporting workout images...");
                     }
                     var imageExporter = new ImageExporter();
-                    imageExporter.ExportToFiles(workouts, outputFolder?.FullName, powerPlans.Count, powerPlans);
+                    imageExporter.ExportToFiles(workouts, effectiveOutputFolder, powerPlans.Count, powerPlans);
                     if (!quiet)
                     {
                         Console.ForegroundColor = ConsoleColor.Green;
-                        Console.WriteLine($"✅ Workout images exported to '{outputFolder?.FullName}' directory");
+                        Console.WriteLine($"✅ Workout images exported to '{effectiveOutputFolder}' directory");
                         Console.ResetColor();
                     }
                     if (verbose)
@@ -370,7 +464,7 @@ rootCommand.SetHandler((inputFile, rotations, outputFolder, formats, dryRun, ver
             Console.WriteLine("✅ All done!");
         }
     }
-}, inputFileOption, rotationsOption, outputFolderOption, formatsOption, dryRunOption, verboseOption, quietOption, noLogoOption);
+});
 
 return await new CommandLineBuilder(rootCommand)
     .UseDefaults()  // Adds standard middleware

--- a/ZwiftTTTSim.Core/Model/Config/RaceConfig.cs
+++ b/ZwiftTTTSim.Core/Model/Config/RaceConfig.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using ZwiftTTTSim.Core.Model.Segments;
+
+namespace ZwiftTTTSim.Core.Model.Config;
+
+public class RaceConfig
+{
+    public string Name { get; set; } = string.Empty;
+
+    public List<ISegment> Route { get; set; } = new List<ISegment>();
+}

--- a/ZwiftTTTSim.Core/Model/Segments/ClimbSegment.cs
+++ b/ZwiftTTTSim.Core/Model/Segments/ClimbSegment.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace ZwiftTTTSim.Core.Model.Segments;
+
+/// <summary>
+/// Represents a climbing segment with a predefined fixed duration.
+/// </summary>
+public class ClimbSegment : ISegment
+{
+    /// <summary>
+    /// Gets or sets the fixed duration of the climb in seconds.
+    /// </summary>
+    public double DurationSeconds { get; set; }
+
+    /// <summary>
+    /// Gets the time representation of the segment's duration limit.
+    /// Ensures duration consistency for JSON serialization and core logic.
+    /// </summary>
+    public TimeSpan Duration => TimeSpan.FromSeconds(DurationSeconds);
+}

--- a/ZwiftTTTSim.Core/Model/Segments/FlatSegment.cs
+++ b/ZwiftTTTSim.Core/Model/Segments/FlatSegment.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace ZwiftTTTSim.Core.Model.Segments;
+
+/// <summary>
+/// Represents a flat segment where duration is dynamically estimated 
+/// based on distance and average speed expectations.
+/// </summary>
+public class FlatSegment : ISegment
+{
+    /// <summary>
+    /// Gets or sets the distance of the segment in kilometers.
+    /// </summary>
+    public double DistanceKm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target average speed for the segment in kilometers per hour.
+    /// </summary>
+    public double AvgSpeedKph { get; set; }
+
+    /// <summary>
+    /// Gets the calculated duration of the segment.
+    /// Ensures duration consistency for JSON serialization and core logic.
+    /// </summary>
+    public TimeSpan Duration
+    {
+        get
+        {
+            if (AvgSpeedKph <= 0)
+            {
+                return TimeSpan.Zero;
+            }
+
+            return TimeSpan.FromSeconds((DistanceKm / AvgSpeedKph) * 3600);
+        }
+    }
+}

--- a/ZwiftTTTSim.Core/Model/Segments/ISegment.cs
+++ b/ZwiftTTTSim.Core/Model/Segments/ISegment.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ZwiftTTTSim.Core.Model.Segments;
+
+/// <summary>
+/// Defines a race segment with a calculable or predefined duration.
+/// </summary>
+public interface ISegment
+{
+    /// <summary>
+    /// Gets the computed or defined duration for the segment workflow.
+    /// </summary>
+    TimeSpan Duration { get; }
+}

--- a/ZwiftTTTSim.Core/Services/PacelinePlanComposer.cs
+++ b/ZwiftTTTSim.Core/Services/PacelinePlanComposer.cs
@@ -1,9 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using ZwiftTTTSim.Core.Model;
+using ZwiftTTTSim.Core.Model.Segments;
 
 namespace ZwiftTTTSim.Core.Services;
 
 public class PacelinePlanComposer
 {
+    private const double DefaultClimbWkg = 4.0;
+
+    /// <summary>
+    /// Creates a PacelinePlan based on the provided rider power plans and a target route of segments.
+    /// Supports dynamic rotation calculation and mixed segment pacing logic.
+    /// </summary>
+    /// <param name="powerPlans">List of RiderPowerPlan objects representing each rider's power plan.</param>
+    /// <param name="route">List of ISegment objects making up the course.</param>
+    /// <returns>PacelinePlan object representing the entire race plan.</returns>
+    public PacelinePlan CreatePlan(List<RiderPowerPlan> powerPlans, List<ISegment> route)
+    {
+        var plan = new PacelinePlan();
+        var rotationOrder = new List<RiderPowerPlan>(powerPlans);
+
+        foreach (var segment in route)
+        {
+            if (segment is FlatSegment flatSegment)
+            {
+                var rotationDurationSeconds = powerPlans.Sum(p => p.PullDuration.TotalSeconds);
+                var segmentDurationSeconds = flatSegment.Duration.TotalSeconds;
+
+                // Calculate rotations with rounding away from zero
+                var rawRotations = segmentDurationSeconds / rotationDurationSeconds;
+                var rotations = (int)Math.Round(rawRotations, MidpointRounding.AwayFromZero);
+
+                // Ensure a minimum of 1 rotation
+                if (rotations < 1)
+                {
+                    rotations = 1;
+                }
+
+                int totalPulls = rotations * rotationOrder.Count;
+
+                for (int pull = 0; pull < totalPulls; pull++)
+                {
+                    var leader = rotationOrder[0];
+                    var pullDuration = leader.PullDuration;
+
+                    var currentPull = new Pull
+                    {
+                        PullNumber = plan.Pulls.Count + 1,
+                        PullDuration = pullDuration,
+                        PacelinePositions = new List<PacelinePosition>()
+                    };
+
+                    for (int position = 0; position < rotationOrder.Count; position++)
+                    {
+                        var currentRider = rotationOrder[position];
+                        var targetPower = currentRider.GetPowerByPosition(position);
+
+                        currentPull.PacelinePositions.Add(new PacelinePosition
+                        {
+                            Rider = currentRider,
+                            PositionInPull = position,
+                            TargetPower = targetPower
+                        });
+                    }
+                    plan.Pulls.Add(currentPull);
+                    
+                    rotationOrder.Add(rotationOrder[0]);
+                    rotationOrder.RemoveAt(0);
+                }
+            }
+            else if (segment is ClimbSegment climbSegment)
+            {
+                var climbPull = new Pull
+                {
+                    PullNumber = plan.Pulls.Count + 1,
+                    PullDuration = climbSegment.Duration,
+                    PacelinePositions = new List<PacelinePosition>()
+                };
+
+                for (int position = 0; position < rotationOrder.Count; position++)
+                {
+                    var currentRider = rotationOrder[position];
+                    var targetPower = currentRider.RiderData.Weight * DefaultClimbWkg;
+
+                    climbPull.PacelinePositions.Add(new PacelinePosition
+                    {
+                        Rider = currentRider,
+                        PositionInPull = position,
+                        TargetPower = targetPower
+                    });
+                }
+
+                plan.Pulls.Add(climbPull);
+            }
+        }
+
+        return plan;
+    }
+
     /// <summary>
     /// Creates a PacelinePlan based on the provided rider power plans and number of rotations.
     /// </summary>

--- a/ZwiftTTTSim.Core/Services/RaceConfigParser.cs
+++ b/ZwiftTTTSim.Core/Services/RaceConfigParser.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ZwiftTTTSim.Core.Model.Config;
+using ZwiftTTTSim.Core.Model.Segments;
+
+namespace ZwiftTTTSim.Core.Services;
+
+public class RaceConfigParser
+{
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public RaceConfigParser()
+    {
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new SegmentConverter() }
+        };
+    }
+
+    public RaceConfig Parse(string jsonContent)
+    {
+        if (string.IsNullOrWhiteSpace(jsonContent))
+        {
+            throw new ArgumentException("JSON content cannot be null or empty.", nameof(jsonContent));
+        }
+
+        try
+        {
+            var config = JsonSerializer.Deserialize<RaceConfig>(jsonContent, _jsonOptions);
+            
+            if (config == null || config.Route == null || config.Route.Count == 0)
+            {
+                throw new InvalidOperationException("Parsed race configuration is invalid or contains no segments.");
+            }
+
+            return config;
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Failed to parse JSON configuration: {ex.Message}", ex);
+        }
+    }
+}
+
+public class SegmentConverter : JsonConverter<ISegment>
+{
+    public override ISegment? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        var root = document.RootElement;
+
+        if (!root.TryGetProperty("type", out var typeProperty))
+        {
+            throw new JsonException("Missing 'type' property on segment definition.");
+        }
+
+        var type = typeProperty.GetString()?.ToLowerInvariant();
+
+        return type switch
+        {
+            "flat" => JsonSerializer.Deserialize<FlatSegment>(root.GetRawText(), options),
+            "climb" => JsonSerializer.Deserialize<ClimbSegment>(root.GetRawText(), options),
+            _ => throw new JsonException($"Unknown segment type: {type}")
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ISegment value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, (object)value, options);
+    }
+}

--- a/ZwiftTTTSim.Tests/Model/SegmentTests.cs
+++ b/ZwiftTTTSim.Tests/Model/SegmentTests.cs
@@ -1,0 +1,58 @@
+using System;
+using Xunit;
+using ZwiftTTTSim.Core.Model.Segments;
+
+namespace ZwiftTTTSim.Tests.Model;
+
+public class SegmentTests
+{
+    [Fact]
+    public void FlatSegment_CalculatesDuration_FromDistanceAndSpeed()
+    {
+        // Arrange
+        var flatSegment = new FlatSegment
+        {
+            DistanceKm = 10,
+            AvgSpeedKph = 40
+        };
+
+        // Act
+        var result = flatSegment.Duration;
+
+        // Assert
+        Assert.Equal(TimeSpan.FromSeconds(900), result);
+    }
+
+    [Fact]
+    public void FlatSegment_ReturnsZeroDuration_WhenSpeedIsZero()
+    {
+        // Arrange
+        var flatSegment = new FlatSegment
+        {
+            DistanceKm = 10,
+            AvgSpeedKph = 0
+        };
+
+        // Act
+        var result = flatSegment.Duration;
+
+        // Assert
+        Assert.Equal(TimeSpan.Zero, result);
+    }
+
+    [Fact]
+    public void ClimbSegment_ReturnsDuration_FromSeconds()
+    {
+        // Arrange
+        var climbSegment = new ClimbSegment
+        {
+            DurationSeconds = 300
+        };
+
+        // Act
+        var result = climbSegment.Duration;
+
+        // Assert
+        Assert.Equal(TimeSpan.FromMinutes(5), result);
+    }
+}

--- a/ZwiftTTTSim.Tests/PacelinePlanComposerTests.cs
+++ b/ZwiftTTTSim.Tests/PacelinePlanComposerTests.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using ZwiftTTTSim.Core.Model;
+using ZwiftTTTSim.Core.Model.Segments;
 using ZwiftTTTSim.Core.Services;
 
 namespace ZwiftTTTSim.Tests;
@@ -385,5 +386,76 @@ public class PacelinePlanComposerTests
         Assert.Equal(380, plan.Pulls[3].PacelinePositions[0].TargetPower); // pos 0 (repeats)
         Assert.Equal(260, plan.Pulls[4].PacelinePositions[2].TargetPower); // pos 2
         Assert.Equal(320, plan.Pulls[5].PacelinePositions[1].TargetPower); // pos 1
+    }
+
+    [Fact]
+    public void CreatePlan_WithSegments_RoundsRotationsCorrectly()
+    {
+        // Arrange
+        var powerPlans = TestData.GetSampleRiderPowerPlans(); // 4 riders: 225s per rotation
+        // 1.5 rotations = 337.5 seconds
+        // Distance = (337.5 / 3600) * 40kph = 3.75 km
+        var flatSegment = new FlatSegment { DistanceKm = 3.75, AvgSpeedKph = 40 };
+        
+        var composer = new PacelinePlanComposer();
+        var route = new List<ISegment> { flatSegment };
+
+        // Act
+        var plan = composer.CreatePlan(powerPlans, route);
+
+        // Assert
+        // 1.5 rotations rounds away from zero to 2 rotations -> 8 pulls
+        Assert.Equal(8, plan.Pulls.Count);
+    }
+
+    [Fact]
+    public void CreatePlan_WithSegments_EnsuresMinimumOneRotation()
+    {
+        // Arrange
+        var powerPlans = TestData.GetSampleRiderPowerPlans(); // 4 riders: 225s per rotation
+        // Tiny segment -> 10 seconds -> 0.044 rotations
+        var flatSegment = new FlatSegment { DistanceKm = 0.1, AvgSpeedKph = 36 };
+        
+        var composer = new PacelinePlanComposer();
+        var route = new List<ISegment> { flatSegment };
+
+        // Act
+        var plan = composer.CreatePlan(powerPlans, route);
+
+        // Assert
+        // Minimum 1 rotation -> 4 pulls
+        Assert.Equal(4, plan.Pulls.Count);
+    }
+
+    [Fact]
+    public void CreatePlan_WithSegments_HandlesMixedPlan()
+    {
+        // Arrange
+        var powerPlans = TestData.GetSampleRiderPowerPlans(); // 4 riders: 225s per rotation
+        var route = new List<ISegment>
+        {
+            new FlatSegment { DistanceKm = 2.5, AvgSpeedKph = 40 }, // 1 rotation (4 pulls)
+            new ClimbSegment { DurationSeconds = 300 }, // 1 fixed effort pull
+            new FlatSegment { DistanceKm = 2.5, AvgSpeedKph = 40 }  // 1 rotation (4 pulls)
+        };
+        
+        var composer = new PacelinePlanComposer();
+
+        // Act
+        var plan = composer.CreatePlan(powerPlans, route);
+
+        // Assert
+        // 4 pulls + 1 pull + 4 pulls = 9 pulls
+        Assert.Equal(9, plan.Pulls.Count);
+
+        // Check climb pull (index 4)
+        var climbPull = plan.Pulls[4];
+        Assert.Equal(300, climbPull.PullDuration.TotalSeconds);
+        
+        // Ensure default W/kg power is applied (4.0 W/kg)
+        foreach (var pos in climbPull.PacelinePositions)
+        {
+            Assert.Equal(pos.Rider.RiderData.Weight * 4.0, pos.TargetPower);
+        }
     }
 }


### PR DESCRIPTION
## 🏁 Summary
This PR implements the full core infrastructure for the "Climb-aware pacing" roadmap. It transitions the simulator from a basic fixed-rotation tool to a course-aware engine capable of processing complex race layouts via JSON configuration.

## 🚀 Key Improvements
- **Course Normalization (#52, #55):** Implemented the `ISegment` interface to handle distance-based sections (`FlatSegment`) and duration-based sections (`ClimbSegment`) with internal `TimeSpan` normalization.
- **Dynamic Rotation Math (#53):** Integrated `MidpointRounding.AwayFromZero` logic to resolve how many rotations fit into a specific segment, ensuring a minimum of 1 rotation per block to prevent simulation collapse.
- **RaceConfig Parser (#49):** Added a robust JSON parser using `System.Text.Json` with discriminative logic to handle polymorphic segments.
- **CLI Enhancement (#57):** Added the `--race <file>` flag with built-in mutual exclusivity handling for the legacy `--rotations` flag (#56).
- **Automated Workflow:** Output files (.zwo and .png) are now professionally organized into subfolders based on the race name defined in the JSON.

## 🧪 Quality Assurance
- **TDD Approach:** Added `SegmentTests.cs` and significantly expanded `PacelinePlanComposerTests.cs` to cover mixed-segment scenarios.
- **Edge Case Handling:** Verified safety against division by zero (0 km/h) and validated that extremely short segments default to a single rotation.
- **Physics-Lite Validation:** Confirmed that climb segments correctly apply weight-based power metrics (W/kg) for all riders.

## 📝 Developer Note
A `DEVELOPER_NOTE.md` has been included in the root directory. This document outlines the architectural choices made and provides a guide for future contributors to extend the segment system (e.g., adding Sprint or Technical segments).

**This PR closes (https://github.com/simonech/zwift-ttt-race-simulator/issues/49), (https://github.com/simonech/zwift-ttt-race-simulator/issues/52) (https://github.com/simonech/zwift-ttt-race-simulator/issues/53) (https://github.com/simonech/zwift-ttt-race-simulator/issues/55) (https://github.com/simonech/zwift-ttt-race-simulator/issues/56) (https://github.com/simonech/zwift-ttt-race-simulator/issues/57)**